### PR TITLE
Fix bug that causes dedup.py to fail to write out files

### DIFF
--- a/dupliganger/dedup.py
+++ b/dupliganger/dedup.py
@@ -686,8 +686,6 @@ def write_output_files_pe(parent_db, read_group_db, dup_db, umi_error_db,
         * A umi-error-rejects file. - Reads rejected due to error in UMI.
     """
     ## Write everything except the dup_group_sam_like file.
-    WORKED = 0  #LESLIE TESTING
-    DIDNT_WORK = 0 #LESLIE TESTING
     with parent_db.begin(False) as txn, \
             sambamopen(input_file) as fin, \
             open(dedupped_sam, 'w') as f_dedupped_sam, \

--- a/dupliganger/dedup.py
+++ b/dupliganger/dedup.py
@@ -686,6 +686,8 @@ def write_output_files_pe(parent_db, read_group_db, dup_db, umi_error_db,
         * A umi-error-rejects file. - Reads rejected due to error in UMI.
     """
     ## Write everything except the dup_group_sam_like file.
+    WORKED = 0  #LESLIE TESTING
+    DIDNT_WORK = 0 #LESLIE TESTING
     with parent_db.begin(False) as txn, \
             sambamopen(input_file) as fin, \
             open(dedupped_sam, 'w') as f_dedupped_sam, \
@@ -763,13 +765,14 @@ def write_output_files_pe(parent_db, read_group_db, dup_db, umi_error_db,
             ## Have a group of alignment lines with same QNAME, write to files.
 
             # First, add dupliganger SAM TAGs if its in the umi_error_db
+            
             if prev_qname in umi_error_db:
                 # Error in UMI, add sdd-specific umi error tags.
                 new_aln_lines = []
                 for i, line in enumerate(aln_lines):
                     # Update the alignment line with sam tags
-                    line_with_sam_tags = '\t'.join(
-                            (aln_lines[i].rstrip(), umi_error_db[prev_qname][i]))
+                    index_sam_tag = i%2
+                    line_with_sam_tags = '\t'.join((aln_lines[i].rstrip(), umi_error_db[prev_qname][index_sam_tag]))
                     line_with_sam_tags += '\n'
                     new_aln_lines.append(line_with_sam_tags)
                 aln_lines = new_aln_lines

--- a/dupliganger/dedup.py
+++ b/dupliganger/dedup.py
@@ -844,9 +844,12 @@ def parse_args(args):
                 " If passing --correct, you must also pass --keep-bad-umis.")
 
     # Which store to use
-    if args['--store'] not in (STORE_OPTION_LMDB, STORE_OPTION_MEMORY):
+    if args['--store'] == None:
+        store = STORE_OPTION_MEMORY
+    elif args['--store'] not in (STORE_OPTION_LMDB, STORE_OPTION_MEMORY):
         raise CannotContinueException("""Store {} is not supported.""".format(args['--store']))
-    store = args['--store']
+    else:
+        store = args['--store']
 
     outdir = args_to_out_dir(args)
 


### PR DESCRIPTION
# Index out of range
dedup.py was failing with:
```
Traceback (most recent call last):
File "~/miniconda3/envs/test_dupli/bin/dupliganger", line 8, in <module>
	sys.exit(main_wrapper())
File "~/miniconda3/envs/test_dupli/lib/python3.6/site-packages/dupliganger/command_line.py", line 46, in main_wrapper
	dupliganger.dupliganger.main()
File "~/miniconda3/envs/test_dupli/lib/python3.6/site-packages/dupliganger/dupliganger.py", line 113, in main
	cmd_module.main()
File "~/miniconda3/envs/test_dupli/lib/python3.6/site-packages/dupliganger/dedup.py", line 1101, in main
	run(*parse_args(args))
File "~/miniconda3/envs/test_dupli/lib/python3.6/site-packages/dupliganger/dedup.py", line 1041, in run
	write_umi_error_rejects, write_sam_headers)
File "~/miniconda3/envs/test_dupli/lib/python3.6/site-packages/dupliganger/dedup.py", line 772, in write_output_files_pe
	(aln_lines[i].rstrip(), umi_error_db[prev_qname][i]))
IndexError: tuple index out of range
```
Occurs when there are >2 alignment lines with the same umi error since there are only ever 2 values in the ```umi_error_db[prev_qname][i]``` tuple. Converted ```i``` to 0 or 1 using modulo to use as new index.

# Default not set for --store
...so I set ```--store=STORE_OPTION_MEMORY``` as specified in the documentation if ```args['--store'] == None```